### PR TITLE
feat(murmurd): ignore erroneous exit when setting supw

### DIFF
--- a/murmur/docker-entrypoint.sh
+++ b/murmur/docker-entrypoint.sh
@@ -91,7 +91,15 @@ if [ ! -f /data/murmur.sqlite ]; then
     fi
 
     echo "SUPERUSER_PASSWORD: $SUPERUSER_PASSWORD"
-    /opt/murmur/murmur.x86 -ini "${CONFIGFILE}" -supw $SUPERUSER_PASSWORD
+
+    # Using -supw currently throws a fatal error and exits the program. It has
+    # been fixed in the upstream project by commit d8203ba94 [1], after the
+    # current version (1.3.0). To bypass the issue and allow the entrypoint
+    # script to proceed, we are ignoring the erroneous exit code by executing
+    # `true` if the first invocation fails.
+    #
+    # [1]: https://github.com/mumble-voip/mumble/commit/d8203ba94d528b092e0ff5a52a51af28f8f592f1
+    /opt/murmur/murmur.x86 -ini "${CONFIGFILE}" -supw $SUPERUSER_PASSWORD || true
 fi
 
 # Run murmur if not in debug mode


### PR DESCRIPTION
Using -supw when invoking the murmur executable throws a fatal error and
exits the program. To bypass this, we use an OR operator and execute
`true`.

This issue is fixed in the upstream project by commit d8203ba94 [1];
this patch can be reverted in the future when a new version containing
the patch is released.

[1]: https://github.com/mumble-voip/mumble/commit/d8203ba94d528b092e0ff5a52a51af28f8f592f1

resolves sudoforge/docker-images#92
references mumble-voip/mumble#3911