### PR TITLE
feat(mumble-server): use exec to start murmur

### DIFF
--- a/mumble-server/docker-entrypoint.sh
+++ b/mumble-server/docker-entrypoint.sh
@@ -103,5 +103,5 @@ fi
 
 # Run murmur if not in debug mode
 if [ -z "$DEBUG" ] || [ ! "$DEBUG" -eq 1 ]; then
-    /opt/murmur/murmur.x86 -fg -ini "${CONFIGFILE}"
+    exec /opt/murmur/murmur.x86 -fg -ini "${CONFIGFILE}"
 fi


### PR DESCRIPTION
Mumble 1.3 contains the ability to live-reload the SSL/TLS certificate
(see [the pull request][0] or [the commit][1]) by sending a SIGUSR1
signal to the server; this is especially useful when automatically
uploading the certificate, from, for example, LetsEncrypt (certbot).

This patch uses `exec` to replace PID1 (currently the entrypoint script)
with the mumble process.

[0]: https://github.com/mumble-voip/mumble/pull/2850
[1]: https://github.com/mumble-voip/mumble/commit/1742f8698377b187a6dabc0047ab64e4ad00dc35

PR Closes: sudoforge/docker-images#98